### PR TITLE
Fix #3 Limit number of chars to display on the front page

### DIFF
--- a/frontend/app/components/PreviewBlogComponent.js
+++ b/frontend/app/components/PreviewBlogComponent.js
@@ -4,12 +4,13 @@ var Link = ReactRouter.Link;
 
 var previewBlogComponent = React.createClass({
     render: function(){
+        //If body is larger than 1000 chars, limit to 1000 and add dotdotdot
+        var body = this.props.blogpost.body.length > 1000 ? this.props.blogpost.body.substring(0,1000) + "..." : this.props.blogpost.body;
         return(
             <div className="blogPostPreview">
                 <h2> <Link to={`/post/${this.props.blogpost.slug}`}>{this.props.blogpost.title} </Link> </h2>
-                //If there is no user, a testuser is displayed. Should throw an error when system is in prod
-                <div className="author"><p> Written by: <span className="authorName"> {this.props.blogpost.author ? this.props.blogpost.author.username : "Magination"} </span> </p></div>
-                <p> {this.props.blogpost.body} </p>
+                <div className="author"><p> Written by: <span className="authorName"> Juul Arthur </span> </p></div>
+                <p> {body} </p>
                 <Link to={`/post/${this.props.blogpost.slug}`}><button name="readMoreButton">Read more</button></Link>
             </div>
         )


### PR DESCRIPTION
Limits the number of chars displayed of a post to 1000 and adds `...` if so. May break HTML-tags.
